### PR TITLE
Fishing

### DIFF
--- a/YetAnotherFishingMod/.nexusmods/changelog_v1.2.0.txt
+++ b/YetAnotherFishingMod/.nexusmods/changelog_v1.2.0.txt
@@ -1,4 +1,5 @@
 Version 1.2.0
 
-- Hotfix for Stardew Valley 1.6.9+ compatibility.
+- Updated harmony patch for infinite bait and tackles for Stardew Valley 1.6.9+ compatibility.
 - Infinite tackles option should now work as intended, the workaround of also enabling infinite bait is no longer necessary.
+- Updated harmony patch for AutoLootFish option for Stardew Valley 1.6.9/1.6.14+ compatibility.

--- a/YetAnotherFishingMod/.nexusmods/changelog_v1.2.0.txt
+++ b/YetAnotherFishingMod/.nexusmods/changelog_v1.2.0.txt
@@ -1,0 +1,4 @@
+Version 1.2.0
+
+- Hotfix for Stardew Valley 1.6.9+ compatibility.
+- Infinite tackles option should now work as intended, the workaround of also enabling infinite bait is no longer necessary.

--- a/YetAnotherFishingMod/Framework/Patches.cs
+++ b/YetAnotherFishingMod/Framework/Patches.cs
@@ -32,7 +32,7 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             ApplyPatches();
         }
 
-        private static void ApplyPatches()
+        public static void ApplyPatches()
         {
             s_harmony.Patch(
                 original: AccessTools.Method(typeof(FishingRod), nameof(FishingRod.tickUpdate)),
@@ -55,7 +55,7 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             );
         }
 
-        private static IEnumerable<CodeInstruction> FishingRodTickUpdatePatch(ILGenerator generator, IEnumerable<CodeInstruction> instructions)
+        public static IEnumerable<CodeInstruction> FishingRodTickUpdatePatch(ILGenerator generator, IEnumerable<CodeInstruction> instructions)
         {
             List<CodeInstruction> output = [];
 
@@ -75,7 +75,7 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             return output;
         }
 
-        private static IEnumerable<CodeInstruction> BobberBar_Update_Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instructions)
+        public static IEnumerable<CodeInstruction> BobberBar_Update_Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instructions)
         {
             CodeMatcher codeMatcher = new(instructions, generator);
 
@@ -149,7 +149,7 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             return codeMatcher.InstructionEnumeration();
         }
 
-        private static IEnumerable<CodeInstruction> FishingRod_DoDoneFishing_Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instructions)
+        public static IEnumerable<CodeInstruction> FishingRod_DoDoneFishing_Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instructions)
         {
             CodeMatcher codeMatcher = new(instructions, generator);
 
@@ -218,7 +218,7 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             return codeMatcher.InstructionEnumeration();
         }
 
-        private static IEnumerable<CodeInstruction> GameLocation_GetFishFromLocationData_Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instructions)
+        public static IEnumerable<CodeInstruction> GameLocation_GetFishFromLocationData_Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instructions)
         {
             CodeMatcher codeMatcher = new(instructions, generator);
 
@@ -259,7 +259,7 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             return filteredPossibleFish.AsEnumerable();
         }
 
-        private static bool IsFishInPreferredCategory(ParsedItemData fish)
+        public static bool IsFishInPreferredCategory(ParsedItemData fish)
         {
             ModConfig config = s_config();
 
@@ -278,37 +278,37 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             return false;
         }
 
-        private static bool DoSkipVibration()
+        public static bool DoSkipVibration()
         {
             return s_config().DisableVibrations;
         }
 
-        private static bool HasInfiniteTackle()
+        public static bool HasInfiniteTackle()
         {
             return s_config().InfiniteTackle;
         }
 
-        private static bool HasInfiniteBait()
+        public static bool HasInfiniteBait()
         {
             return s_config().InfiniteBait;
         }
 
-        private static float TreasureInBarMultiplier()
+        public static float TreasureInBarMultiplier()
         {
             return 0.0135f * s_config().TreasureInBarMultiplier;
         }
 
-        private static float FishInBarMultiplier()
+        public static float FishInBarMultiplier()
         {
             return 0.002f * s_config().FishInBarMultiplier;
         }
 
-        private static bool DoAutoLootFish()
+        public static bool DoAutoLootFish()
         {
             return s_config().AutoLootFish;
         }
 
-        private static bool PullFishFromWaterPatch(ref int fishDifficulty)
+        public static bool PullFishFromWaterPatch(ref int fishDifficulty)
         {
             try
             {

--- a/YetAnotherFishingMod/Framework/Patches.cs
+++ b/YetAnotherFishingMod/Framework/Patches.cs
@@ -65,7 +65,7 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             {
                 if (instruction.opcode == OpCodes.Ldstr && (string)instruction.operand == "coin")
                 {
-                    output.Insert(output.Count - 17, new CodeInstruction(OpCodes.Call, SymbolExtensions.GetMethodInfo(() => DoAutoLootFish())));
+                    output.Insert(output.Count - 17, new CodeInstruction(OpCodes.Call, typeof(Patches).GetMethod(nameof(DoAutoLootFish))));
                     output.Insert(output.Count - 17, new CodeInstruction(OpCodes.Brtrue, label));
                     output[^2].labels.Add(label);
                 }
@@ -98,7 +98,7 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
                 .Advance(1)
                 .RemoveInstruction()
                 .Insert(
-                    new CodeInstruction(OpCodes.Call, SymbolExtensions.GetMethodInfo(() => FishInBarMultiplier()))
+                    new CodeInstruction(OpCodes.Call, typeof(Patches).GetMethod(nameof(FishInBarMultiplier)))
                 );
 
             codeMatcher.Start();
@@ -120,7 +120,7 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
                 .Advance(1)
                 .RemoveInstruction()
                 .Insert(
-                    new CodeInstruction(OpCodes.Call, SymbolExtensions.GetMethodInfo(() => TreasureInBarMultiplier()))
+                    new CodeInstruction(OpCodes.Call, typeof(Patches).GetMethod(nameof(TreasureInBarMultiplier)))
                 );
 
             codeMatcher.Start();
@@ -138,7 +138,7 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             }
 
             codeMatcher.InsertAndAdvance(
-                new(OpCodes.Call, SymbolExtensions.GetMethodInfo(() => DoSkipVibration())),
+                new(OpCodes.Call, typeof(Patches).GetMethod(nameof(DoSkipVibration))),
                 new(OpCodes.Brtrue, skipVibrationsLabel)
             );
 
@@ -173,7 +173,7 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             }
 
             codeMatcher.Insert(
-                new(OpCodes.Call, SymbolExtensions.GetMethodInfo(() => HasInfiniteBait())),
+                new(OpCodes.Call, typeof(Patches).GetMethod(nameof(HasInfiniteBait))),
                 new(OpCodes.Brtrue, infiniteBaitLabel)
             );
 
@@ -193,7 +193,7 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             }
 
             codeMatcher.Insert(
-                new(OpCodes.Call, SymbolExtensions.GetMethodInfo(() => HasInfiniteTackle())),
+                new(OpCodes.Call, typeof(Patches).GetMethod(nameof(HasInfiniteTackle))),
                 new(OpCodes.Brtrue, infiniteTackleLabel)
             );
 

--- a/YetAnotherFishingMod/Framework/Patches.cs
+++ b/YetAnotherFishingMod/Framework/Patches.cs
@@ -151,8 +151,6 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
 
         public static IEnumerable<CodeInstruction> FishingRod_DoDoneFishing_Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instructions)
         {
-            s_monitor.Log("Patching FishingRod.doDoneFishing");
-
             CodeMatcher codeMatcher = new(instructions, generator);
 
             Label infiniteBaitLabel = generator.DefineLabel();
@@ -216,8 +214,6 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             }
 
             codeMatcher.AddLabels(new[] { infiniteTackleLabel });
-
-            s_monitor.Log("Done patching FishingRod.doDoneFishing");
 
             return codeMatcher.InstructionEnumeration();
         }
@@ -289,15 +285,11 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
 
         public static bool HasInfiniteTackle()
         {
-            s_monitor.Log($"Applying infinite tackle: {s_config().InfiniteTackle}");
-
             return s_config().InfiniteTackle;
         }
 
         public static bool HasInfiniteBait()
         {
-            s_monitor.Log($"Applying infinite bait: {s_config().InfiniteBait}");
-
             return s_config().InfiniteBait;
         }
 

--- a/YetAnotherFishingMod/Framework/Patches.cs
+++ b/YetAnotherFishingMod/Framework/Patches.cs
@@ -151,6 +151,8 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
 
         public static IEnumerable<CodeInstruction> FishingRod_DoDoneFishing_Transpiler(ILGenerator generator, IEnumerable<CodeInstruction> instructions)
         {
+            s_monitor.Log("Patching FishingRod.doDoneFishing");
+
             CodeMatcher codeMatcher = new(instructions, generator);
 
             Label infiniteBaitLabel = generator.DefineLabel();
@@ -214,6 +216,8 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
             }
 
             codeMatcher.AddLabels(new[] { infiniteTackleLabel });
+
+            s_monitor.Log("Done patching FishingRod.doDoneFishing");
 
             return codeMatcher.InstructionEnumeration();
         }
@@ -285,11 +289,15 @@ namespace NeverToxic.StardewMods.YetAnotherFishingMod.Framework
 
         public static bool HasInfiniteTackle()
         {
+            s_monitor.Log($"Applying infinite tackle: {s_config().InfiniteTackle}");
+
             return s_config().InfiniteTackle;
         }
 
         public static bool HasInfiniteBait()
         {
+            s_monitor.Log($"Applying infinite bait: {s_config().InfiniteBait}");
+
             return s_config().InfiniteBait;
         }
 

--- a/YetAnotherFishingMod/manifest.json
+++ b/YetAnotherFishingMod/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Yet Another Fishing Mod",
   "Author": "NeverToxic",
-  "Version": "1.1.3-alpha.20240405",
+  "Version": "1.2.0",
   "Description": "Automatically catch fish and treasure.",
   "UniqueID": "NeverToxic.YetAnotherFishingMod",
   "EntryDll": "YetAnotherFishingMod.dll",

--- a/YetAnotherFishingMod/manifest.json
+++ b/YetAnotherFishingMod/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Yet Another Fishing Mod",
   "Author": "NeverToxic",
-  "Version": "1.1.3-alpha",
+  "Version": "1.1.3-alpha.20240405",
   "Description": "Automatically catch fish and treasure.",
   "UniqueID": "NeverToxic.YetAnotherFishingMod",
   "EntryDll": "YetAnotherFishingMod.dll",

--- a/YetAnotherFishingMod/manifest.json
+++ b/YetAnotherFishingMod/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Yet Another Fishing Mod",
   "Author": "NeverToxic",
-  "Version": "1.1.2",
+  "Version": "1.1.3-alpha",
   "Description": "Automatically catch fish and treasure.",
   "UniqueID": "NeverToxic.YetAnotherFishingMod",
   "EntryDll": "YetAnotherFishingMod.dll",


### PR DESCRIPTION
Update for Stardew Valley 1.6.9+ compatibility.

- Updated harmony patch for infinite bait and tackles for Stardew Valley 1.6.9+ compatibility.
- Infinite tackles option should now work as intended, the workaround of also enabling infinite bait is no longer necessary.
- Updated harmony patch for AutoLootFish option for Stardew Valley 1.6.9/1.6.14+ compatibility.
